### PR TITLE
fix(server): obtain garage configuration dynamically

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -32,7 +32,7 @@ lib.callback.register('npwd_qbx_garages:server:getPlayerVehicles', function(sour
 			vehicleData.brand = VEHICLES[model].brand
 		end
 
-		vehicleData.garage = garageConfig.garages[vehicleData.garage]?.label or locale('states.garage_unknown')
+		vehicleData.garage = garageConfig[vehicleData.garage]?.label or locale('states.garage_unknown')
 	end
 
 	return result

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,6 +1,7 @@
 lib.versionCheck('Qbox-project/npwd_qbx_garages')
+assert(GetResourceState('qbx_garages') == 'started', 'qbx_garages is not started')
 
-local config = require '@qbx_garages.config.shared'
+local config = exports.qbx_garages:GetGarages()
 local VEHICLES = exports.qbx_core:GetVehiclesByName()
 
 lib.callback.register('npwd_qbx_garages:server:getPlayerVehicles', function(source)
@@ -35,4 +36,14 @@ lib.callback.register('npwd_qbx_garages:server:getPlayerVehicles', function(sour
 	end
 
 	return result
+end)
+
+AddEventHandler('onResourceStart', function(resourceName)
+    if resourceName == 'qbx_garages' then
+        config = exports.qbx_garages:GetGarages()
+    end
+end)
+
+AddEventHandler('qbx_garages:server:garageRegistered', function(name, config)
+    config[name] = config
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,7 +1,7 @@
 lib.versionCheck('Qbox-project/npwd_qbx_garages')
 assert(GetResourceState('qbx_garages') == 'started', 'qbx_garages is not started')
 
-local config = exports.qbx_garages:GetGarages()
+local garageConfig = exports.qbx_garages:GetGarages()
 local VEHICLES = exports.qbx_core:GetVehiclesByName()
 
 lib.callback.register('npwd_qbx_garages:server:getPlayerVehicles', function(source)
@@ -32,7 +32,7 @@ lib.callback.register('npwd_qbx_garages:server:getPlayerVehicles', function(sour
 			vehicleData.brand = VEHICLES[model].brand
 		end
 
-		vehicleData.garage = config.garages[vehicleData.garage]?.label or locale('states.garage_unknown')
+		vehicleData.garage = garageConfig.garages[vehicleData.garage]?.label or locale('states.garage_unknown')
 	end
 
 	return result
@@ -40,10 +40,10 @@ end)
 
 AddEventHandler('onResourceStart', function(resourceName)
     if resourceName == 'qbx_garages' then
-        config = exports.qbx_garages:GetGarages()
+        garageConfig = exports.qbx_garages:GetGarages()
     end
 end)
 
-AddEventHandler('qbx_garages:server:garageRegistered', function(name, config)
-    config[name] = config
+AddEventHandler('qbx_garages:server:garageRegistered', function(garageName, newGarageConfig)
+    garageConfig[garageName] = newGarageConfig
 end)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes obtaining garage config from `qbx_garages`. Adds event handlers for `qbx_garages` restarts and for garages being registered

Blocked on https://github.com/Qbox-project/qbx_garages/pull/109

Fixes #11 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.